### PR TITLE
Allow graphql-client >= 0.14.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     shopify_graphql_client (0.2.3)
-      graphql-client (~> 0.14.0)
+      graphql-client (>= 0.14.0)
       shopify_api (>= 5.2)
 
 GEM
@@ -85,4 +85,4 @@ DEPENDENCIES
   shopify_graphql_client!
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/shopify_graphql_client.gemspec
+++ b/shopify_graphql_client.gemspec
@@ -38,6 +38,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.17"
   spec.add_development_dependency "rake", "~> 10.0"
 
-  spec.add_runtime_dependency "graphql-client", "~> 0.14.0"
+  spec.add_runtime_dependency "graphql-client", ">= 0.14.0"
   spec.add_runtime_dependency "shopify_api", [">= 5.2"]
 end


### PR DESCRIPTION
We need this change in order to [update](https://github.com/Checkout-X/checkout-x/pull/458) the monolith app to `rails` 6:
The change allow us to use newer version of `graphql-client` which will support `activesupport >= 6.0`

I don't think there is any risk to that, because it was already done in the [original repo](https://github.com/mikeyhew/shopify_graphql_client/commit/c28c9254970cc7fb21f74971998357576882b24e).